### PR TITLE
Use ssl certificate file basename as destination

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
 - name: Copy SSL key and cert for logstash-forwarder.
   copy:
     src: "{{ item }}"
-    dest: "{{ logstash_ssl_dir }}/{{ item }}"
+    dest: "{{ logstash_ssl_dir }}/{{ item | basename }}"
     mode: 0644
   with_items:
     - "{{ logstash_ssl_key_file }}"

--- a/templates/01-lumberjack-input.conf.j2
+++ b/templates/01-lumberjack-input.conf.j2
@@ -2,7 +2,7 @@ input {
   lumberjack {
     port => {{ logstash_listen_port_lumberjack }}
     type => "logs"
-    ssl_certificate => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_file }}"
-    ssl_key => "{{ logstash_ssl_dir }}/{{ logstash_ssl_key_file }}"
+    ssl_certificate => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_file | basename}}"
+    ssl_key => "{{ logstash_ssl_dir }}/{{ logstash_ssl_key_file | basename}}"
   }
 }


### PR DESCRIPTION
Useful when specifying a full or relative path to some certificate in your ansible repo.