### PR TITLE
Upgrade Logstash to 2.x

### DIFF
--- a/files/filters/12-apache.conf
+++ b/files/filters/12-apache.conf
@@ -1,10 +1,10 @@
 filter {
-  grok {
-    type => "apache"
-    pattern => "%{COMBINEDAPACHELOG}"
-  }
-  date {
-    type => "apache"
-    match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
+  if [type] == "apache" {
+      grok {
+        match => { "message" => "%{COMBINEDAPACHELOG}"}
+      }
+      date {
+        match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]
+      }
   }
 }

--- a/files/filters/14-solr.conf
+++ b/files/filters/14-solr.conf
@@ -4,7 +4,7 @@ filter {
       drop { }
     }
     grok {
-      pattern => "<%{POSINT:priority}>%{SYSLOGLINE}"
+      match => { "message" => "<%{POSINT:priority}>%{SYSLOGLINE}"}
     }
     multiline {
       pattern => "(([^\s]+)Exception.+)|(at:.+)"

--- a/files/filters/15-drupal.conf
+++ b/files/filters/15-drupal.conf
@@ -1,7 +1,7 @@
 filter {
   if [type] == "drupal" {
     grok {
-      match => ["message", "%{SYSLOGTIMESTAMP} %{HOST} %{WORD}: %{URI:drupal_vhost}\|%{NUMBER:drupal_timestamp}\|(?<drupal_action>[^\|]*)\|%{IP:drupal_ip}\|(?<drupal_request_uri>[^\|]*)\|(?<drupal_referer>[^\|]*)\|(?<drupal_uid>[^\|]*)\|(?<drupal_link>[^\|]*)\|%{GREEDYDATA:drupal_message}" ]
+      match => ["message", "%{SYSLOGTIMESTAMP} %{HOSTNAME} %{WORD}: %{URI:drupal_vhost}\|%{NUMBER:drupal_timestamp}\|(?<drupal_action>[^\|]*)\|%{IP:drupal_ip}\|(?<drupal_request_uri>[^\|]*)\|(?<drupal_referer>[^\|]*)\|(?<drupal_uid>[^\|]*)\|(?<drupal_link>[^\|]*)\|%{GREEDYDATA:drupal_message}" ]
     }
   }
 }

--- a/files/logstash.repo
+++ b/files/logstash.repo
@@ -1,6 +1,6 @@
-[logstash-1.4]
-name=logstash repository for 1.4.x packages
-baseurl=http://packages.elasticsearch.org/logstash/1.4/centos
+[logstash-2.3]
+name=Logstash repository for 2.3.x packages
+baseurl=http://packages.elastic.co/logstash/2.3/centos
 gpgcheck=1
-gpgkey=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
 enabled=1

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,7 +6,7 @@
 
 - name: Add Logstash repository.
   apt_repository:
-    repo: 'deb http://packages.elasticsearch.org/logstash/1.4/debian stable main'
+    repo: 'deb http://packages.elasticsearch.org/logstash/2.3/debian stable main'
     state: present
 
 - name: Check if Logstash is already installed.

--- a/templates/30-lumberjack-output.conf.j2
+++ b/templates/30-lumberjack-output.conf.j2
@@ -1,5 +1,6 @@
 output {
   elasticsearch {
-    host => {{ logstash_elasticsearch_host }}
+    hosts => ["{{ logstash_elasticsearch_host }}"]
+    template_overwrite => true
   }
 }


### PR DESCRIPTION
Hello,

ElasticSearch 2.x is incompatible with LogStash 1.x. When use geerlingguy.elasticsearch it makes some headaches.