### PR TITLE
Logstash 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,25 @@ env:
   - distro: centos7
     init: /usr/lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    el_version: 2.x
   - distro: ubuntu1604
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    el_version: 2.x
+  - distro: ubuntu1604
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    el_version: 5.x
   - distro: ubuntu1404
     init: /sbin/init
     run_opts: ""
+    el_version: 2.x
 
 before_install:
   # Pull container.
   - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
+  # elasticsearch 5.x requirement
+  - 'sudo sysctl -w vm.max_map_count=262144'
 
 script:
   - container_id=$(mktemp)
@@ -28,11 +37,11 @@ script:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
 
   # Test role.
-  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
+  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -e elasticsearch_repo_version=${el_version} -e logstash_repo_version=${el_version}'
 
   # Test role idempotence.
   - idempotence=$(mktemp)
-  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
+  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -e elasticsearch_repo_version=${el_version} -e logstash_repo_version=${el_version} | tee -a ${idempotence}
   - >
     tail ${idempotence}
     | grep -q 'changed=0.*failed=0'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
+
+## 5.x requires java8!
+#logstash_repo_version: 5.x
+logstash_repo_version: 2.x
+
 logstash_listen_port_beats: 5044
 
 logstash_elasticsearch_hosts:

--- a/files/logstash.repo
+++ b/files/logstash.repo
@@ -1,6 +1,0 @@
-[logstash-2.3]
-name=Logstash repository for 2.3.x packages
-baseurl=http://packages.elastic.co/logstash/2.3/centos
-gpgcheck=1
-gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
-enabled=1

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,15 +1,22 @@
 ---
+- set_fact:
+    logstash_dir: /opt/logstash
+  when: logstash_repo_version ==  '2.x'
+- set_fact:
+    logstash_dir: /usr/share/logstash
+  when: logstash_repo_version ==  '5.x'
+
 - name: Get list of installed plugins.
   command: >
     ./bin/logstash-plugin list
-    chdir=/opt/logstash
+    chdir={{ logstash_dir }}
   register: logstash_plugins_list
   changed_when: false
 
 - name: Install configured plugins.
   command: >
     ./bin/logstash-plugin install {{ item }}
-    chdir=/opt/logstash
+    chdir={{ logstash_dir }}
   with_items: "{{ logstash_install_plugins }}"
   when: "item not in logstash_plugins_list.stdout"
   notify: restart logstash

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,8 @@
 ---
+
+- name: Add apt-transport-https package
+  package: name=apt-transport-https state=present
+
 - name: Add Elasticsearch apt key.
   apt_key:
     url: http://packages.elasticsearch.org/GPG-KEY-elasticsearch

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,18 +4,19 @@
     url: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
     state: present
 
-- name: Add Logstash repository.
+- name: Add Logstash repository. - 2.x
   apt_repository:
     repo: 'deb http://packages.elasticsearch.org/logstash/2.3/debian stable main'
     state: present
+    update_cache: yes
+  when: logstash_repo_version ==  '2.x'
 
-- name: Check if Logstash is already installed.
-  stat: path=/etc/init.d/logstash
-  register: logstash_installed
-
-- name: Update apt cache if repository just added.
-  apt: update_cache=yes
-  when: logstash_installed.stat.exists == false
+- name: Add Logstash repository. - 5.x
+  apt_repository:
+    repo: 'deb https://artifacts.elastic.co/packages/5.x/apt stable main'
+    state: present
+    update_cache: yes
+  when: logstash_repo_version ==  '5.x'
 
 - name: Install Logstash.
   apt: pkg=logstash state=present

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -5,8 +5,8 @@
     state: present
 
 - name: Add Logstash repository.
-  copy:
-    src: logstash.repo
+  template:
+    src: logstash.repo.j2
     dest: /etc/yum.repos.d/logstash.repo
     mode: 0644
 

--- a/templates/logstash.repo.j2
+++ b/templates/logstash.repo.j2
@@ -1,0 +1,17 @@
+{% if logstash_repo_version == '2.x' %}
+[logstash-2.3]
+name=Logstash repository for 2.3.x packages
+baseurl=http://packages.elastic.co/logstash/2.3/centos
+gpgcheck=1
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+{% else %}
+[logstash-5.x]
+name=Elastic repository for 5.x packages
+baseurl=https://artifacts.elastic.co/packages/5.x/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
+{% endif %}


### PR DESCRIPTION
add option for repo between elastic 2.x or 5.x - latest requires java8
travis test include only for xenial as only one with java8 in official distribution