### PR TITLE
Add support for arbitrary logstash outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The port over which Logstash will listen for beats.
 
-    logstash_elasticsearch_hosts:
-      - http://localhost:9200
+    logstash_outputs:
+      elasticsearch:
+        hosts: [ "http://localhost:9200" ]
+        index: "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+        document_type: "%{[@metadata][type]}"
 
-The hosts where Logstash should ship logs to Elasticsearch.
+The default output which sends logs to a local Elasticsearch node.
 
     logstash_ssl_dir: /etc/pki/logstash
     logstash_ssl_certificate_file: logstash-forwarder-example.crt

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,11 @@
 ---
 logstash_listen_port_beats: 5044
 
-logstash_elasticsearch_hosts:
-  - http://localhost:9200
+logstash_outputs:
+  elasticsearch:
+    hosts: [ "http://localhost:9200" ]
+    index: "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    document_type: "%{[@metadata][type]}"
 
 logstash_local_syslog_path: /var/log/syslog
 logstash_monitor_local_syslog: true

--- a/filter_plugins/logstash.py
+++ b/filter_plugins/logstash.py
@@ -1,0 +1,26 @@
+def to_logstash(arg, indent=4, oneline=False):
+  if isinstance(arg, dict):
+    lines = []
+    for k,v in arg.iteritems():
+      if isinstance(v, dict):
+        fragment = '%s => { %s }' % (k, to_logstash(v, oneline=True))
+      else:
+        fragment = '%s => %s' % (k, to_logstash(v, oneline=True))
+      lines.append(fragment)
+
+    if oneline:
+      prefix = ' '
+    else:
+      prefix = '\n' + (' ' * indent)
+    out = prefix.join(lines)
+  elif hasattr(arg, '__iter__'):
+    out = '[ %s ]' % ', '.join([ to_logstash(i, oneline=True) for i in arg])
+  else:
+    out = arg
+
+  return out
+
+
+class FilterModule(object):
+  def filters(self):
+    return {'to_logstash': to_logstash}

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -8,7 +8,7 @@
     mode: 0644
   with_items:
     - 01-beats-input.conf
-    - 30-elasticsearch-output.conf
+    - 30-output.conf
   notify: restart logstash
 
 - name: Create Logstash filters.

--- a/templates/30-elasticsearch-output.conf.j2
+++ b/templates/30-elasticsearch-output.conf.j2
@@ -1,7 +1,0 @@
-output {
-  elasticsearch {
-    hosts => {{ logstash_elasticsearch_hosts | to_json }}
-    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
-    document_type => "%{[@metadata][type]}"
-  }
-}

--- a/templates/30-output.conf.j2
+++ b/templates/30-output.conf.j2
@@ -1,0 +1,18 @@
+output {
+{% if logstash_elasticsearch_hosts is defined %}
+{# deprecated #}
+# The ansible variable 'logstash_elasticsearch_hosts' is deprecated.
+# Please consider switching to the more generic 'logstash_outputs' variable.
+  elasticsearch {
+    hosts => {{ logstash_elasticsearch_hosts | to_json }}
+    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}"
+  }
+{% else %}
+{% for name, params in logstash_outputs.iteritems() %}
+  {{ name }} {
+    {{ params | to_logstash }}
+  }
+{% endfor %}
+{% endif %}
+}


### PR DESCRIPTION
For backwards-compatibility, if the variable `logstash_elasticsearch_hosts`
is set then use the deprecated hard-coded elasticsearch output section;
otherwise, construct an arbitrary number of outputs from the `logstash_outputs`
variable.

A filter_plugin has been added to ease converting the yaml datastructure to the
custom syntax used by logstash configs.