### PR TITLE
Add a method to specify LS_USER for Redhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Set this to `no` if you don't want logstash to run on system startup.
 
 A list of Logstash plugins that should be installed.
 
+If logstash needs to be run as different user on Redhat, you can use following variable:
+
+    logstash_user: logstash
+
+
 ## Other Notes
 
 If you are seeing high CPU usage from one of the `logstash` processes, and you're using Logstash along with another application running on port 80 on a platform like Ubuntu with upstart, the `logstash-web` process may be stuck in a loop trying to start on port 80, failing, and trying to start again, due to the `restart` flag being present in `/etc/init/logstash-web.conf`. To avoid this problem, either change that line to add a `limit` to the respawn statement, or set the `logstash-web` service to `enabled=no` in your playbook, e.g.:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,5 @@ logstash_enabled_on_boot: yes
 
 logstash_install_plugins:
   - logstash-input-beats
+
+logstash_user: logstash

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -42,3 +42,13 @@
     state: absent
   when: not logstash_monitor_local_syslog
   notify: restart logstash
+
+- name: Add sysconfig for logstash (Redhat)
+  template:
+    src: logstash-sysconfig.j2
+    dest: /etc/sysconfig/logstash
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart logstash
+  when: ansible_os_family == "RedHat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: setup-RedHat.yml
-    when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat'
 
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+    when: ansible_os_family == 'RedHat'
 
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'

--- a/templates/logstash-sysconfig.j2
+++ b/templates/logstash-sysconfig.j2
@@ -1,0 +1,5 @@
+###############################
+# Default settings for logstash
+###############################
+
+LS_USER={{ logstash_user }}


### PR DESCRIPTION
This pull request adds a variable so that user can be specified for running logstash upstart scripts on RedHat systems.