### PR TITLE
Support for SSL with self signed Certificate Authority

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ logstash_local_syslog_path: /var/log/syslog
 logstash_monitor_local_syslog: true
 
 logstash_ssl_dir: /etc/pki/logstash
+logstash_ssl_certificate_authority: ""
 logstash_ssl_certificate_file: ""
 logstash_ssl_key_file: ""
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ logstash_elasticsearch_hosts:
 logstash_local_syslog_path: /var/log/syslog
 logstash_monitor_local_syslog: true
 
+logstash_ssl: false
 logstash_ssl_dir: /etc/pki/logstash
 logstash_ssl_certificate_authority: ""
 logstash_ssl_certificate_file: ""

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -13,5 +13,6 @@
   with_items:
     - "{{ logstash_ssl_key_file }}"
     - "{{ logstash_ssl_certificate_file }}"
+    - "{{ logstash_ssl_certificate_authority }}"
   notify: restart logstash
   when: logstash_ssl_key_file

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ logstash_ssl_dir }}"
     state: directory
-  when: logstash_ssl_key_file
+  when: logstash_ssl
 
 - name: Copy SSL key and cert for logstash-forwarder.
   copy:
@@ -15,4 +15,4 @@
     - "{{ logstash_ssl_certificate_file }}"
     - "{{ logstash_ssl_certificate_authority }}"
   notify: restart logstash
-  when: logstash_ssl_key_file
+  when: logstash_ssl

--- a/templates/01-beats-input.conf.j2
+++ b/templates/01-beats-input.conf.j2
@@ -1,7 +1,7 @@
 input {
   beats {
     port => {{ logstash_listen_port_beats }}
-{% if logstash_ssl_certificate_file and logstash_ssl_key_file %}
+{% if logstash_ssl %}
     ssl => true
     ssl_certificate_authorities => ["{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_authority | basename }}"]
     ssl_certificate => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_file | basename }}"

--- a/templates/01-beats-input.conf.j2
+++ b/templates/01-beats-input.conf.j2
@@ -3,6 +3,7 @@ input {
     port => {{ logstash_listen_port_beats }}
 {% if logstash_ssl_certificate_file and logstash_ssl_key_file %}
     ssl => true
+    ssl_certificate_authorities => ["{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_authority | basename }}"]
     ssl_certificate => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_file | basename }}"
     ssl_key => "{{ logstash_ssl_dir }}/{{ logstash_ssl_key_file | basename }}"
     ssl_verify_mode => "force_peer"


### PR DESCRIPTION
Related to https://github.com/geerlingguy/ansible-role-filebeat/pull/17

I've been playing around to get a secured connection between Filebeat and Logstash.

I've setup a self signed CA for this and use the logstash_ssl_certificate_authority directive to include it. I guess it would be cleaner to have list of CAs instead of one, but I can't wrap my head around on how to get that into the Jinja template. Feel free to give suggestions.

I've also done a few other changes, please check the individual commits.