### PR TITLE
Logstash 5.x moved from /opt to /usr

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -2,14 +2,14 @@
 - name: Get list of installed plugins.
   command: >
     ./bin/logstash-plugin list
-    chdir=/opt/logstash
+    chdir=/usr/share/logstash
   register: logstash_plugins_list
   changed_when: false
 
 - name: Install configured plugins.
   command: >
     ./bin/logstash-plugin install {{ item }}
-    chdir=/opt/logstash
+    chdir=/usr/share/logstash
   with_items: "{{ logstash_install_plugins }}"
   when: "item not in logstash_plugins_list.stdout"
   notify: restart logstash


### PR DESCRIPTION
Related issues:
* https://github.com/geerlingguy/ansible-role-logstash/issues/28
* https://github.com/geerlingguy/ansible-role-logstash/issues/25

I'm not sure how to get this through the CI though.