### PR TITLE
Add option to install filters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,9 @@ logstash_listen_port_beats: 5044
 logstash_elasticsearch_hosts:
   - http://localhost:9200
 
-logstash_local_syslog_path: /var/log/syslog
+logstash_install_input_output: true
 logstash_install_filters: true
+logstash_local_syslog_path: /var/log/syslog
 logstash_monitor_local_syslog: true
 
 logstash_ssl_dir: /etc/pki/logstash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ logstash_elasticsearch_hosts:
   - http://localhost:9200
 
 logstash_local_syslog_path: /var/log/syslog
+logstash_install_filters: true
 logstash_monitor_local_syslog: true
 
 logstash_ssl_dir: /etc/pki/logstash

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -24,6 +24,7 @@
     - 12-apache.conf
     - 14-solr.conf
     - 15-drupal.conf
+  when: logstash_install_filters
   notify: restart logstash
 
 - name: Create Logstash configuration file for local syslog.

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,6 +9,7 @@
   with_items:
     - 01-beats-input.conf
     - 30-elasticsearch-output.conf
+  when: logstash_install_input_output
   notify: restart logstash
 
 - name: Create Logstash filters.


### PR DESCRIPTION
Related issue: https://github.com/geerlingguy/ansible-role-logstash/issues/31

I implemented this as the 12-solr.conf filter uses logstash-filter-multiline, which is removed from 5.6 and deprecated for some time.

