### PR TITLE
Change `when` expression to `logstash_ssl_key_file is defined`

### DIFF
--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ logstash_ssl_dir }}"
     state: directory
-  when: logstash_ssl_key_file
+  when: logstash_ssl_key_file is defined
 
 - name: Copy SSL key and cert for logstash-forwarder.
   copy:
@@ -14,4 +14,4 @@
     - "{{ logstash_ssl_key_file }}"
     - "{{ logstash_ssl_certificate_file }}"
   notify: restart logstash
-  when: logstash_ssl_key_file
+  when: logstash_ssl_key_file is defined


### PR DESCRIPTION
This is to avoid the error

```
The conditional check '{{ logstash_ssl_key_file }}' failed. The error
was: error while evaluating conditional ({{ logstash_ssl_key_file }}):
'server' is undefined

The error appears to have been in 'roles/geerlingguy.logstash/tasks/ssl.yml':
line 2, column 3, but may be elsewhere in the file depending on the
exact syntax problem.

The offending line appears to be:

---

name: Ensure Logstash SSL key pair directory exists.
^ here
}

```