### PR TITLE
Remove the multiline filter as it's no longer supported, fixes #41

### DIFF
--- a/files/filters/14-solr.conf
+++ b/files/filters/14-solr.conf
@@ -6,10 +6,5 @@ filter {
     grok {
       match => { "message" => "<%{POSINT:priority}>%{SYSLOGLINE}"}
     }
-    multiline {
-      pattern => "(([^\s]+)Exception.+)|(at:.+)"
-      stream_identity => "%{logsource}.%{@type}"
-      what => "previous"
-    }
   }
 }

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -20,7 +20,7 @@
 
 - name: Update apt cache if repository just added.
   apt: update_cache=yes
-  when: logstash_installed.stat.exists == false
+  when: logstash_installed.stat.exists
 
 - name: Install Logstash.
   apt:


### PR DESCRIPTION
I looked at how you'd replace the filter with the codec. The codec can't be used conditionally.

 The new way to handle the collapsing of multiple lines is [in the filebeat configuration instead.](https://discuss.elastic.co/t/multiline-codec-in-if-else-condition-in-beat-input-of-logstash/110323)