### PR TITLE
Add ssl support and allow logstash to run on a separate host

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,19 +6,34 @@ update_java: True
 
 logstash_listen_port_beats: 5044
 
-logstash_elasticsearch_hosts:
-  - http://localhost:9200
-
 logstash_local_syslog_path: /var/log/syslog
 logstash_monitor_local_syslog: true
-
-logstash_dir: /usr/share/logstash
-
-logstash_ssl_dir: /etc/pki/logstash
-logstash_ssl_certificate_file: ""
-logstash_ssl_key_file: ""
 
 logstash_enabled_on_boot: true
 
 logstash_install_plugins:
   - logstash-input-beats
+
+logstash_dir: /usr/share/logstash
+
+# Options for how logstash connects to elasticsearch
+logstash_elasticsearch_hosts:
+  - http://localhost:9200
+
+# Whether to use HTTP basic-auth when connect to ES
+logstash_es_user:
+logstash_es_pass:
+
+# Whether to use SSL when conenct to ES
+logstash_es_use_ssl: false
+logstash_es_insecure_ssl: false
+
+# Options for logstash's own SSL client certificate
+logstash_ssl_dir: /etc/pki/logstash
+logstash_ssl_certificate_file:
+logstash_ssl_certificate_authority:
+
+# Note that logstash wants a PK8 format key file!
+# Convert from PEM with this command:
+#     openssl pkcs8 -inform pem -in your.key -nocrypt -topk8 -out your.pk8
+logstash_ssl_key_file:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 logstash_version: '6.x'
 
+logstash_java_install: True
+update_java: True
+
 logstash_listen_port_beats: 5044
 
 logstash_elasticsearch_hosts:

--- a/files/filters/14-solr.conf
+++ b/files/filters/14-solr.conf
@@ -6,10 +6,5 @@ filter {
     grok {
       match => { "message" => "<%{POSINT:priority}>%{SYSLOGLINE}"}
     }
-    multiline {
-      pattern => "(([^\s]+)Exception.+)|(at:.+)"
-      stream_identity => "%{logsource}.%{@type}"
-      what => "previous"
-    }
   }
 }

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -33,12 +33,12 @@
     owner: root
     group: root
     mode: 0644
-  when: logstash_monitor_local_syslog
+  when: logstash_monitor_local_syslog | bool
   notify: restart logstash
 
 - name: Ensure configuration for local syslog is absent if disabled.
   file:
     path: /etc/logstash/conf.d/02-local-syslog-input.conf
     state: absent
-  when: not logstash_monitor_local_syslog
+  when: not logstash_monitor_local_syslog | bool
   notify: restart logstash

--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -1,0 +1,53 @@
+---
+
+- name: set fact java_state to present
+  set_fact: java_state="present"
+
+- name: set fact java_state to latest
+  set_fact: java_state="latest"
+  when: update_java | bool
+
+- name: RedHat - Ensure Java is installed
+  become: yes
+  yum: name={{ java }} state={{java_state}}
+  when: ansible_os_family == 'RedHat'
+
+- name: RedHat - Get the installed java path
+  shell: "update-alternatives --display java | grep '^/' | awk '{print $1}' | grep 1.8.0 | head -1"
+  become: yes
+  register: java_full_path
+  failed_when: False
+  changed_when: False
+  check_mode: no
+  when: ansible_os_family == 'RedHat'
+
+- name: RedHat - correct java version selected
+  alternatives:
+    name: java
+    path: "{{ java_full_path.stdout }}"
+    link: /usr/bin/java
+  when: ansible_os_family == 'RedHat' and java_full_path is defined
+
+- name: Debian - Refresh java repo
+  become: yes
+  apt: update_cache=yes
+  when: ansible_os_family == 'Debian'
+
+- name: Debian - Ensure Java is installed
+  become: yes
+  apt: name={{ java }} state={{java_state}}
+  when: ansible_os_family == 'Debian'
+
+- name: register open_jdk version
+  shell: java -version 2>&1 | grep OpenJDK
+  register: open_jdk
+  ignore_errors: yes
+  changed_when: False
+  check_mode: no
+
+#https://github.com/docker-library/openjdk/issues/19 - ensures tests pass due to java 8 broken certs
+- name: Ubuntu - refresh the java ca-certificates
+  become: yes
+  command: /var/lib/dpkg/info/ca-certificates-java.postinst configure
+  when: ansible_distribution == 'Ubuntu' and open_jdk.rc == 0
+  changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: os-specific vars
+  include_vars: "{{ansible_os_family}}.yml"
+
+- name: include java.yml
+  include: java.yml
+  when: logstash_java_install | bool
+  tags:
+      - java
+
 - name: Include OS Specific setup tasks
   include: setup-{{ ansible_os_family }}.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,8 +11,9 @@
 - name: Include OS Specific setup tasks
   include: setup-{{ ansible_os_family }}.yml
 
-- include: config.yml
 - include: ssl.yml
+
+- include: config.yml
 - include: plugins.yml
 
 - name: Ensure Logstash is started and enabled on boot.

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ logstash_ssl_dir }}"
     state: directory
-  when: logstash_ssl_key_file
+  when: logstash_ssl_key_file | bool
 
 - name: Copy SSL key and cert for logstash-forwarder.
   copy:
@@ -14,4 +14,4 @@
     - "{{ logstash_ssl_key_file }}"
     - "{{ logstash_ssl_certificate_file }}"
   notify: restart logstash
-  when: logstash_ssl_key_file
+  when: logstash_ssl_key_file | bool

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -1,17 +1,48 @@
 ---
-- name: Ensure Logstash SSL key pair directory exists.
+- local_action: stat path="{{ role_path }}/files/{{ logstash_ssl_key_file }}"
+  register: logstash_keyfile
+
+- local_action: stat path="{{ role_path }}/files/{{ logstash_ssl_certificate_file }}"
+  register: logstash_crtfile
+
+- local_action: stat path="{{ role_path }}/files/{{ logstash_ssl_certificate_authority }}"
+  register: logstash_cafile
+
+- name: Ensure Logstash SSL directory exists.
   file:
     path: "{{ logstash_ssl_dir }}"
     state: directory
-  when: logstash_ssl_key_file | bool
+    owner: "logstash"
+    group: "logstash"
+    mode: 0700
+  when: (logstash_keyfile.stat.exists|bool and logstash_keyfile.stat.isreg|bool) or (logstash_crtfile.stat.exists|bool and logstash_crtfile.stat.isreg|bool) or (logstash_cafile.stat.exists|bool and logstash_cafile.stat.isreg|bool)
 
-- name: Copy SSL key and cert for logstash-forwarder.
+- name: Upload client SSL key for logstash-forwarder.
   copy:
-    src: "{{ item }}"
-    dest: "{{ logstash_ssl_dir }}/{{ item | basename }}"
-    mode: 0644
-  with_items:
-    - "{{ logstash_ssl_key_file }}"
-    - "{{ logstash_ssl_certificate_file }}"
+    src: "{{ logstash_ssl_key_file }}"
+    dest: "{{ logstash_ssl_dir }}/{{ logstash_ssl_key_file | basename }}"
+    mode: 0600
+    owner: "logstash"
+    group: "logstash"
+  when: logstash_keyfile.stat.exists|bool and logstash_keyfile.stat.isreg|bool
   notify: restart logstash
-  when: logstash_ssl_key_file | bool
+
+- name: Upload client SSL certificate for logstash-forwarder.
+  copy:
+    src: "{{ logstash_ssl_certificate_file }}"
+    dest: "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_file | basename }}"
+    mode: 0600
+    owner: "logstash"
+    group: "logstash"
+  when: logstash_crtfile.stat.exists|bool and logstash_crtfile.stat.isreg|bool
+  notify: restart logstash
+
+- name: Upload local certificate authority file
+  copy:
+    src: "{{ logstash_ssl_certificate_authority }}"
+    dest: "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_authority | basename }}"
+    mode: 0600
+    owner: "logstash"
+    group: "logstash"
+  notify: restart logstash
+  when: logstash_cafile.stat.exists|bool and logstash_cafile.stat.isreg|bool

--- a/templates/01-beats-input.conf.j2
+++ b/templates/01-beats-input.conf.j2
@@ -1,11 +1,20 @@
 input {
   beats {
     port => {{ logstash_listen_port_beats }}
-{% if logstash_ssl_certificate_file and logstash_ssl_key_file %}
+{% if logstash_es_use_ssl|bool %}
     ssl => true
+{% endif %}
+{% if logstash_crtfile.stat.exists|bool and logstash_crtfile.stat.isreg|bool %}
     ssl_certificate => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_file | basename }}"
+{% endif %}
+{% if logstash_keyfile.stat.exists|bool and logstash_keyfile.stat.isreg|bool %}
     ssl_key => "{{ logstash_ssl_dir }}/{{ logstash_ssl_key_file | basename }}"
-    ssl_verify_mode => "force_peer"
+{% endif %}
+{% if logstash_cafile.stat.exists|bool and logstash_cafile.stat.isreg|bool %}
+    ssl_certificate_authorities => ["{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_authority | basename}}"]
+{% endif %}
+{% if logstash_es_insecure_ssl %}
+    ssl_verify_mode => "none"
 {% endif %}
   }
 }

--- a/templates/30-elasticsearch-output.conf.j2
+++ b/templates/30-elasticsearch-output.conf.j2
@@ -1,7 +1,42 @@
 output {
-  elasticsearch {
-    hosts => {{ logstash_elasticsearch_hosts | to_json }}
-    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
-    document_type => "%{[@metadata][type]}"
+  if [@metadata][pipeline] {
+    elasticsearch {
+      hosts => {{ logstash_elasticsearch_hosts | to_json }}
+      manage_template => false
+      index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+      document_type => "%{[@metadata][type]}"
+      pipeline => "%{[@metadata][pipeline]}"
+{% if logstash_es_user|length>0 %}
+      user => "{{ logstash_es_user }}"
+{% endif %}
+{% if logstash_es_pass|length>0 %}
+      password => "{{ logstash_es_pass }}"
+{% endif %}
+{% if logstash_es_use_ssl|bool %}
+      ssl => true
+{% endif %}
+{% if logstash_cafile.stat.exists|bool and logstash_cafile.stat.isreg|bool %}
+      cacert => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_authority | basename }}"
+{% endif %}
+    }
+  } else {
+    elasticsearch {
+      manage_template => false
+      hosts => {{ logstash_elasticsearch_hosts | to_json }}
+      index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+      document_type => "%{[@metadata][type]}"
+{% if logstash_es_user|length>0 %}
+      user => "{{ logstash_es_user }}"
+{% endif %}
+{% if logstash_es_pass|length>0 %}
+      password => "{{ logstash_es_pass }}"
+{% endif %}
+{% if logstash_es_use_ssl|bool %}
+      ssl => true
+{% endif %}
+{% if logstash_cafile.stat.exists|bool and logstash_cafile.stat.isreg|bool %}
+      cacert => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_authority | basename }}"
+{% endif %}
+    }
   }
 }

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+---
+java: "{% if es_java is defined %}{{es_java}}{% else %}openjdk-8-jre-headless{% endif %}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,2 @@
+---
+java: "{{ es_java | default('java-1.8.0-openjdk.x86_64') }}"


### PR DESCRIPTION
This PR combines two changes I made downstream. Let me know if you'd like them split into separate PR's.

- Import java handling from the ElasticSearch role, allowing LogStash to be installed and run on an independent host
- Config changes to allow handling of externally-created SSL certificates so that LogStash can be secured