### PR TITLE
Add Logic for Specifying Logstash Package Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The major version of Logstash to install.
 
+    logstash_package_version: ''
+
+The specific package version of Logstash to install.
+
     logstash_listen_port_beats: 5044
 
 The port over which Logstash will listen for beats.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 logstash_version: '7.x'
 
+logstash_package_version: ''
+
 logstash_listen_port_beats: 5044
 
 logstash_elasticsearch_hosts:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -28,6 +28,13 @@
   apt:
     name: logstash
     state: present
+  when: logstash_package_version == ''
+
+- name: Install specific Logstash package version.
+  apt: 
+    name: "logstash={{ logstash_package_version }}"
+    state: present
+  when: logstash_package_version != ''
 
 - name: Add Logstash user to adm group (Debian).
   user:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -14,3 +14,10 @@
   package:
     name: logstash
     state: present
+  when: logstash_package_version == ''
+
+- name: Install specific Logstash version.
+  package:
+    name: "logstash-{{ logstash_package_version }}"
+    state: present
+  when: logstash_package_version != ''


### PR DESCRIPTION
Add variable and install logic to allow for installation of specific non-latest version of logstash.

Implement a `logstash_package_version` variable with a default of '' to allow for installation of a specific minor version of logstash i.e. 7.5.0 instead of just the latest of the major version.