### PR TITLE
Option to install repo (or skip) and option to install default configs (or skip)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 logstash_version: '7.x'
+logstash_manage_repo: true
 
 logstash_listen_port_beats: 5044
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ logstash_elasticsearch_hosts:
 logstash_local_syslog_path: /var/log/syslog
 logstash_monitor_local_syslog: true
 
+logstash_install_default_config: true
+
 logstash_dir: /usr/share/logstash
 
 logstash_ssl_dir: /etc/pki/logstash

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,6 +9,7 @@
   with_items:
     - 01-beats-input.conf
     - 30-elasticsearch-output.conf
+  when: logstash_install_default_config
   notify: restart logstash
 
 - name: Create Logstash filters.
@@ -24,6 +25,7 @@
     - 12-apache.conf
     - 14-solr.conf
     - 15-drupal.conf
+  when: logstash_install_default_config
   notify: restart logstash
 
 - name: Create Logstash configuration file for local syslog.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,7 +5,6 @@
       - apt-transport-https
       - gnupg2
     state: present
-  when: logstash_manage_repo
 
 - name: Add Elasticsearch apt key.
   apt_key:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,17 +5,20 @@
       - apt-transport-https
       - gnupg2
     state: present
+  when: logstash_manage_repo
 
 - name: Add Elasticsearch apt key.
   apt_key:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
+  when: logstash_manage_repo
 
 - name: Add Logstash repository.
   apt_repository:
     repo: 'deb https://artifacts.elastic.co/packages/{{ logstash_version }}/apt stable main'
     state: present
     update_cache: true
+  when: logstash_manage_repo
 
 - name: Install Logstash.
   apt:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -3,12 +3,14 @@
   rpm_key:
     key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
+  when: logstash_manage_repo
 
 - name: Add Logstash repository.
   template:
     src: logstash.repo.j2
     dest: /etc/yum.repos.d/logstash.repo
     mode: 0644
+  when: logstash_manage_repo
 
 - name: Install Logstash.
   package:


### PR DESCRIPTION
Added variable to control the setup of the default DB/RPM repo.
This way - if disabled - packages are fetched from whatever repository is configured in the operating system (and not from the default elastic repos).

Also introduced a variable to skip installation of the default input/output/filter configurations.