### PR TITLE
create systemd file on centos 7 if not exists

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -20,3 +20,4 @@
   command:
     cmd: "{{ logstash_dir }}/bin/system-install /etc/logstash/startup.options systemd"
     creates: /etc/systemd/system/logstash.service
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -14,3 +14,9 @@
   package:
     name: logstash
     state: present
+
+# https://discuss.elastic.co/t/logstash-service-unit-not-found-centos-7/138446
+- name: Add Logstash systemd unit file
+  command:
+    cmd: "{{ logstash_dir }}/bin/system-install /etc/logstash/startup.options systemd"
+    creates: /etc/systemd/system/logstash.service


### PR DESCRIPTION
This PR fixs Logstash post-install-script bug for RHEL/Centos 7 and re-run the script with correct parameters. 

More infos: [Logstash.service: Unit not found (CentOS 7)](https://discuss.elastic.co/t/logstash-service-unit-not-found-centos-7/138446)
