### PR TITLE
Allow to specify logstash package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The major version of Logstash to install.
 
+    logstash_package: logstash
+
+The specific package to be installed. You can specify a version of the package using the correct syntax for your platform and package manager by changing the package name.
+
     logstash_listen_port_beats: 5044
 
 The port over which Logstash will listen for beats.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 logstash_version: '7.x'
 
+logstash_package: logstash
+
 logstash_listen_port_beats: 5044
 
 logstash_elasticsearch_hosts:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -19,7 +19,7 @@
 
 - name: Install Logstash.
   apt:
-    name: logstash
+    name: '{{ logstash_package }}'
     state: present
 
 - name: Add Logstash user to adm group (Debian).


### PR DESCRIPTION
Allows to specify the package version, following the same functionality from [ geerlingguy/ansible-role-kibana ](https://github.com/geerlingguy/ansible-role-kibana)