### PR TITLE
Add Part to set  Java Heap size for Logstash

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ See [Generating a self-signed certificate](#generating-a-self-signed-certificate
 
 Whether configuration for local syslog file (defined as `logstash_local_syslog_path`) should be added to logstash. Set this to `false` if you are monitoring the local syslog differently, or if you don't care about the local syslog file. Other local logs can be added by your own configuration files placed inside `/etc/logstash/conf.d`.
 
+    logstash_set_java_heap: false
+    logstash_init_heap: 2G
+    logstash_max_heap: 2G
+
+The heap size which Logstash can use.
+
     logstash_enabled_on_boot: true
 
 Set this to `false` if you don't want logstash to run on system startup.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,7 @@ logstash_install_plugins:
   - logstash-filter-multiline
 
 logstash_setup_default_config: true
+
+logstash_set_java_heap: false
+logstash_init_heap: 2G
+logstash_max_heap: 2G

--- a/tasks/java-heap.yml
+++ b/tasks/java-heap.yml
@@ -1,0 +1,16 @@
+---
+- name: Set Java Min Heap Size
+  ansible.builtin.lineinfile:
+    path: /etc/logstash/jvm.options
+    regexp: '^-Xms'
+    line: -Xms{{ logstash_init_heap }}
+  when: logstash_set_java_heap
+  notify: restart logstash
+
+- name: Set Java Max Heap Size
+  ansible.builtin.lineinfile:
+    path: /etc/logstash/jvm.options
+    regexp: '^-Xmx'
+    line: -Xmx{{ logstash_max_heap }}
+  when: logstash_set_java_heap
+  notify: restart logstash

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
 - include: config.yml
 - include: ssl.yml
 - include: plugins.yml
+- include: java-heap.yml
 
 - name: Ensure Logstash is started and enabled on boot.
   service:


### PR DESCRIPTION
Set Java Heap to a custom Value since Default is 1G.
My default setting would be 2G, but can be increased and decreased as needed.