### PR TITLE
fix include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Include OS Specific setup tasks
-  include: setup-{{ ansible_os_family }}.yml
+  include_tasks: setup-{{ ansible_os_family }}.yml
 
-- include: config.yml
-- include: ssl.yml
-- include: plugins.yml
+- include_tasks: config.yml
+- include_tasks: ssl.yml
+- include_tasks: plugins.yml
 
 - name: Ensure Logstash is started and enabled on boot.
   service:


### PR DESCRIPTION
Fix for deprecated include:
[DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16.